### PR TITLE
Updated instruction in README

### DIFF
--- a/README
+++ b/README
@@ -17,6 +17,7 @@ Execute the following from the src/ directory:
 
     cd ../intro    # build and test a basic client program
     make daytimetcpcli
+    ./daytimetcpcli &
     ./daytimetcpcli 127.0.0.1
 
 If all that works, you're all set to start compiling individual programs.


### PR DESCRIPTION
I successfully installed the programs, but when I wanted to test the `daytimetcpcli` I got the error: `connect error: Connection refused`. I noticed this was because the server, `daytimetcpsrv`, hadn't been started yet, and that starting the server wasn't included in the instructions. So, I updated the README to instruct the reader `daytimetcpcli` to start the server *before* running the client.