### PR TITLE
Add explicit type casting to pointer assignment for macOS clang compatibility

### DIFF
--- a/lib/readline.c
+++ b/lib/readline.c
@@ -31,7 +31,7 @@ readline(int fd, void *vptr, size_t maxlen)
 	ssize_t	n, rc;
 	char	c, *ptr;
 
-	ptr = vptr;
+	ptr = (char *) vptr;
 	for (n = 1; n < maxlen; n++) {
 		if ( (rc = my_read(fd, &c)) == 1) {
 			*ptr++ = c;


### PR DESCRIPTION
Modified the code to include an explicit type cast in the pointer assignment  to resolve a compilation error reported by macOS's clang.