### PR TITLE
Correct build process with Clang on arm64-apple-darwin

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1020,6 +1020,9 @@ case $basic_machine in
 	pmac | pmac-mpw)
 		basic_machine=powerpc-apple
 		;;
+	aarch64-apple)
+		basic_machine=aarch64-apple
+		;;
 	c4x*)
 		basic_machine=c4x-none
 		os=-coff

--- a/lib/wrapsock.c
+++ b/lib/wrapsock.c
@@ -73,6 +73,9 @@ Getsockopt(int fd, int level, int optname, void *optval, socklen_t *optlenptr)
 }
 
 #ifdef	HAVE_INET6_RTH_INIT
+
+#ifndef __THROW
+#define __THROW
 /* Routing Header Option (RFC 3542).  */
 extern socklen_t inet6_rth_space (int __type, int __segments) __THROW;
 extern void *inet6_rth_init (void *__bp, socklen_t __bp_len, int __type,
@@ -82,6 +85,8 @@ extern int inet6_rth_reverse (const void *__in, void *__out) __THROW;
 extern int inet6_rth_segments (const void *__bp) __THROW;
 extern struct in6_addr *inet6_rth_getaddr (const void *__bp, int __index)
      __THROW;
+#endif /* __THROW */
+
 int
 Inet6_rth_space(int type, int segments)
 {


### PR DESCRIPTION
This PR intends to  resolve building error with Clang on macOS (with M1 chip).

### Environment Info

> Mecs-MacBook-Air:unpv13e mec$ gcc --version
> Apple clang version 16.0.0 (clang-1600.0.26.3)
> Target: arm64-apple-darwin24.6.0
> Thread model: posix
> InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

### Problem 1: configure failed: 

> Mecs-MacBook-Air:unpv13e mec$ ./configure 
> checking build system type... Invalid configuration `aarch64-apple-darwin24.6.0': machine `aarch64-apple' not recognized
> configure: error: /bin/sh ./config.sub aarch64-apple-darwin24.6.0 failed

This issue is resolved by adding 'aarch64-apple` into config.sub

### Problem 2: compile error due to __THROW not recognized by clang

> Mecs-MacBook-Air:unpv13e mec$ cd lib
> Mecs-MacBook-Air:lib mec$ make
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o connect_nonb.o connect_nonb.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o connect_timeo.o connect_timeo.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o daemon_inetd.o daemon_inetd.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o daemon_init.o daemon_init.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o dg_cli.o dg_cli.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o dg_echo.o dg_echo.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o error.o error.c
> error.c:102:17: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
>   102 |                 syslog(level, buf);
>       |                               ^~~
> error.c:102:17: note: treat the string as an argument to avoid this
>   102 |                 syslog(level, buf);
>       |                               ^
>       |                               "%s", 
> 1 warning generated.
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o get_ifi_info.o get_ifi_info.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o gf_time.o gf_time.c
> gf_time.c:20:43: warning: format specifies type 'long' but the argument has type '__darwin_suseconds_t' (aka 'int') [-Wformat]
>    20 |         snprintf(str+8, sizeof(str)-8, ".%06ld", tv.tv_usec);
>       |                                          ~~~~~   ^~~~~~~~~~
>       |                                          %06d
> /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
>    57 |   __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
>       |                                                              ^~~~~~~~~~~
> 1 warning generated.
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o host_serv.o host_serv.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o my_addrs.o my_addrs.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o read_fd.o read_fd.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o readline.o readline.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o readn.o readn.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o readable_timeo.o readable_timeo.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o rtt.o rtt.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o signal.o signal.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o signal_intr.o signal_intr.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_bind_wild.o sock_bind_wild.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_cmp_addr.o sock_cmp_addr.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_cmp_port.o sock_cmp_port.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_ntop.o sock_ntop.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_ntop_host.o sock_ntop_host.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_get_port.o sock_get_port.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_set_addr.o sock_set_addr.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_set_port.o sock_set_port.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sock_set_wild.o sock_set_wild.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o sockfd_to_family.o sockfd_to_family.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o str_cli.o str_cli.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o str_echo.o str_echo.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o tcp_connect.o tcp_connect.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o tcp_listen.o tcp_listen.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o tv_sub.o tv_sub.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o udp_client.o udp_client.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o udp_connect.o udp_connect.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o udp_server.o udp_server.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o wraplib.o wraplib.c
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o wrapsock.o wrapsock.c
> wrapsock.c:77:63: error: expected function body after function declarator
>    77 | extern socklen_t inet6_rth_space (int __type, int __segments) __THROW;
>       |                                                               ^
> wrapsock.c:79:25: error: expected function body after function declarator
>    79 |                              int __segments) __THROW;
>       |                                              ^
> wrapsock.c:80:70: error: expected function body after function declarator
>    80 | extern int inet6_rth_add (void *__bp, const struct in6_addr *__addr) __THROW;
>       |                                                                      ^
> wrapsock.c:81:62: error: expected function body after function declarator
>    81 | extern int inet6_rth_reverse (const void *__in, void *__out) __THROW;
>       |                                                              ^
> wrapsock.c:82:50: error: expected function body after function declarator
>    82 | extern int inet6_rth_segments (const void *__bp) __THROW;
>       |                                                  ^
> wrapsock.c:84:6: error: expected function body after function declarator
>    84 |      __THROW;
>       |      ^
> 6 errors generated.
> make: *** [wrapsock.o] Error 1
> 

Check the expanded source file:

> Mecs-MacBook-Air:lib mec$ gcc -E wrapsock.c
> ...
> extern socklen_t inet6_rth_space (int __type, int __segments) __THROW;
> extern void *inet6_rth_init (void *__bp, socklen_t __bp_len, int __type,
>         int __segments) __THROW;
> extern int inet6_rth_add (void *__bp, const struct in6_addr *__addr) __THROW;
> extern int inet6_rth_reverse (const void *__in, void *__out) __THROW;
> extern int inet6_rth_segments (const void *__bp) __THROW;
> extern struct in6_addr *inet6_rth_getaddr (const void *__bp, int __index)
>      __THROW;
> ...
> 

This problem is resolved by define an empty __THROW macro in wrapsock.c, which is the only place where it's used.