### PR TITLE
Correct build process with gcc that has been messed up by PR#14

### DIFF
--- a/lib/wrapsock.c
+++ b/lib/wrapsock.c
@@ -76,6 +76,8 @@ Getsockopt(int fd, int level, int optname, void *optval, socklen_t *optlenptr)
 
 #ifndef __THROW
 #define __THROW
+#endif /* __THROW */
+
 /* Routing Header Option (RFC 3542).  */
 extern socklen_t inet6_rth_space (int __type, int __segments) __THROW;
 extern void *inet6_rth_init (void *__bp, socklen_t __bp_len, int __type,
@@ -85,8 +87,6 @@ extern int inet6_rth_reverse (const void *__in, void *__out) __THROW;
 extern int inet6_rth_segments (const void *__bp) __THROW;
 extern struct in6_addr *inet6_rth_getaddr (const void *__bp, int __index)
      __THROW;
-#endif /* __THROW */
-
 int
 Inet6_rth_space(int type, int segments)
 {


### PR DESCRIPTION
This PR intends to correct the build process with gcc that has been messed up by PR#14. Namely, with:

> $ gcc --version
> gcc (GCC) 15.2.1 20250808 (Red Hat 15.2.1-1)
> Copyright (C) 2025 Free Software Foundation, Inc.
> This is free software; see the source for copying conditions.  There is NO
> warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
>
> $ uname -a
> Linux fedora 6.15.9-201.fc42.x86_64 #1 SMP PREEMPT_DYNAMIC Sat Aug  2 11:37:34 UTC 2025 x86_64 GNU/Linux

We have

> /unpv13e/lib$ make
> gcc -I../lib -g -O2 -D_REENTRANT -Wall   -c -o wrapsock.o wrapsock.c
> wrapsock.c: In function ‘Inet6_rth_space’:
> wrapsock.c:95:15: error: implicit declaration of function ‘inet6_rth_space’; did you mean ‘Inet6_rth_space’? [-Wimplicit-function-declaration]
>    95 |         ret = inet6_rth_space(type, segments);
>       |               ^~~~~~~~~~~~~~~
>       |               Inet6_rth_space
> wrapsock.c: In function ‘Inet6_rth_init’:
> wrapsock.c:107:15: error: implicit declaration of function ‘inet6_rth_init’; did you mean ‘Inet6_rth_init’? [-Wimplicit-function-declaration]
>   107 |         ret = inet6_rth_init(rthbuf, rthlen, type, segments);
>       |               ^~~~~~~~~~~~~~
>       |               Inet6_rth_init
> wrapsock.c:107:13: error: assignment to ‘void *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
>   107 |         ret = inet6_rth_init(rthbuf, rthlen, type, segments);
>       |             ^
> wrapsock.c: In function ‘Inet6_rth_add’:
> wrapsock.c:117:13: error: implicit declaration of function ‘inet6_rth_add’; did you mean ‘Inet6_rth_add’? [-Wimplicit-function-declaration]
>   117 |         if (inet6_rth_add(rthbuf, addr) < 0)
>       |             ^~~~~~~~~~~~~
>       |             Inet6_rth_add
> wrapsock.c: In function ‘Inet6_rth_reverse’:
> wrapsock.c:124:13: error: implicit declaration of function ‘inet6_rth_reverse’; did you mean ‘Inet6_rth_reverse’? [-Wimplicit-function-declaration]
>   124 |         if (inet6_rth_reverse(in, out) < 0)
>       |             ^~~~~~~~~~~~~~~~~
>       |             Inet6_rth_reverse
> wrapsock.c: In function ‘Inet6_rth_segments’:
> wrapsock.c:133:15: error: implicit declaration of function ‘inet6_rth_segments’; did you mean ‘Inet6_rth_segments’? [-Wimplicit-function-declaration]
>   133 |         ret = inet6_rth_segments(rthbuf);
>       |               ^~~~~~~~~~~~~~~~~~
>       |               Inet6_rth_segments
> wrapsock.c: In function ‘Inet6_rth_getaddr’:
> wrapsock.c:145:15: error: implicit declaration of function ‘inet6_rth_getaddr’; did you mean ‘Inet6_rth_getaddr’? [-Wimplicit-function-declaration]
>   145 |         ret = inet6_rth_getaddr(rthbuf, idx);
>       |               ^~~~~~~~~~~~~~~~~
>       |               Inet6_rth_getaddr
> wrapsock.c:145:13: error: assignment to ‘struct in6_addr *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
>   145 |         ret = inet6_rth_getaddr(rthbuf, idx);
>       |             ^
> make: *** [<builtin>: wrapsock.o] Error 1

This error is resolved by narrowing the scope of conditional macro __THROW.

// ---------------------

Sorry for my amateur mistake. @andyrudoff 

ref: https://github.com/unpbook/unpv13e/pull/14